### PR TITLE
Update packages to support PureScript v0.10.5

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-pux-spectacle-codeslide",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -13,10 +13,10 @@
     "output"
   ],
   "dependencies": {
-    "purescript-pux": "^5.0.3",
-    "purescript-pux-spectacle": "^1.2.0"
+    "purescript-pux": "^7.0.0",
+    "purescript-pux-spectacle": "^2.0.0"
   },
   "devDependencies": {
-    "purescript-psci-support": "^1.0.0"
+    "purescript-psci-support": "^2.0.0"
   }
 }


### PR DESCRIPTION
I updated the package dependencies and changed the version number of the `purescript-pux-spectacle` dependency to `^2.0.0`, as to support that package version if the other PR gets merged.